### PR TITLE
Have GitHub Actions upload to PyPi on tag events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,12 +41,29 @@ jobs:
     - name: Build packages
       if: "matrix.python-version == '3.8'"
       run: |
-        pip install -U twine wheel
-        python setup.py sdist bdist_wheel
+        pip install -U twine wheel build
+        pyproject-build .
         twine check dist/*
-    - name: Upload packages
+    - name: Save packages as GitHub Actions artifacts
       if: "matrix.python-version == '3.8'"
       uses: actions/upload-artifact@v3
       with:
         name: flowlogs-reader-packages
-        path: dist/*
+        path: dist/
+
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    permissions:
+      # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+      id-token: write
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
+      with:
+        name: flowlogs-reader-packages
+        path: dist/
+    - name: Upload packages to PyPi
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
         twine check dist/*
     - name: Upload packages
       if: "matrix.python-version == '3.8'"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: flowlogs-reader-packages
         path: dist/*


### PR DESCRIPTION
This [uses OIDC](https://docs.pypi.org/trusted-publishers/) to automatically upload to https://pypi.org/project/flowlogs-reader/.

Config on the PyPi side was done by @mjschultz already. Here's how to tell if either of us screwed it up:

1. merge this PR
2. merge https://github.com/obsrvbl-oss/flowlogs-reader/pull/65, which increases the version number from `5.0.0` to `5.0.1`.
3. make a tag for 5.0.1
4. see if 5.0.1 appears here: https://pypi.org/project/flowlogs-reader/#history